### PR TITLE
Fix the test case by including a cabal.project.

### DIFF
--- a/cabal-testsuite/PackageTests/Regression/T5309/cabal.project
+++ b/cabal-testsuite/PackageTests/Regression/T5309/cabal.project
@@ -1,0 +1,2 @@
+packages:
+  ./


### PR DESCRIPTION
Without this, Cabal finds a cabal.project from an outer directory,
which will be Cabal's own! This does not lead to good results.

Please include the following checklist in your PR:

* [ ] Patches conform to the [coding conventions](https://github.com/haskell/cabal/#conventions).
* [ ] Any changes that could be relevant to users have been recorded in the changelog.
* [ ] The documentation has been updated, if necessary.
* [ ] If the change is docs-only, `[ci skip]` is used to avoid triggering the build bots.

Please also shortly describe how you tested your change. Bonus points for added tests!
